### PR TITLE
Fix doc example for iterator.to_tuple

### DIFF
--- a/website/content/docs/0.13/core/iterator.md
+++ b/website/content/docs/0.13/core/iterator.md
@@ -1293,13 +1293,13 @@ Consumes all values coming from the iterator and places them in a tuple.
 ### Example
 
 ````koto
-('a', 42, (-1, -2)).to_list()
-# -> ['a', 42, (-1, -2)]
+['a', 42, (-1, -2)].to_tuple()
+# -> ('a', 42, (-1, -2))
 ````
 
 {% example_playground_link(version = "0.13") %}
-print ('a', 42, (-1, -2)).to_list()
-# -> ['a', 42, (-1, -2)]
+print ['a', 42, (-1, -2)].to_tuple()
+# -> ('a', 42, (-1, -2))
 
 {% end %}
 ### See also

--- a/website/content/docs/0.14/core/iterator.md
+++ b/website/content/docs/0.14/core/iterator.md
@@ -1293,13 +1293,13 @@ Consumes all values coming from the iterator and places them in a tuple.
 ### Example
 
 ````koto
-('a', 42, (-1, -2)).to_list()
-# -> ['a', 42, (-1, -2)]
+['a', 42, (-1, -2)].to_tuple()
+# -> ('a', 42, (-1, -2))
 ````
 
 {% example_playground_link(version = "0.14") %}
-print ('a', 42, (-1, -2)).to_list()
-# -> ['a', 42, (-1, -2)]
+print ['a', 42, (-1, -2)].to_tuple()
+# -> ('a', 42, (-1, -2))
 
 {% end %}
 ### See also


### PR DESCRIPTION
The example for `iterator.to_tuple` was using the same example as for `iterator.to_list` so I rewrote it.

I didn't take the time to build the site locally to test this but the change was simple enough that I figured I could open the PR anyhow.